### PR TITLE
Added compressible missing npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "accepts": "^1.3.7",
+    "compressible": "^2.0.18",
     "json.sortify": "^2.2.2",
     "redlock": "^4.1.0",
     "uuid": "^8.0.0"


### PR DESCRIPTION
It seems that `compressible` npm dependency is missing (as it's being used in `/src/compressor.js`). You may not notice this issue on local environment as in non-production environment `compression` dependency will be installed (because it's listed as a devDependency) which has the missing `compressible` as a sub-dependency. You may be able to notice this issue if you make use of `compression` middleware.
So, if you DON'T use compressible middleware and you are installing npm dependencies with production flag, you will get `Error: Cannot find module 'compressible'`.

compression npm package should be listed as normal dependency instead of dev dependency, otherwise it will never be installed for production environments as subdependency meaning an error.