### PR TITLE
allow forcing refresh of cache using `x-api-cache-force-fetch`

### DIFF
--- a/src/apicache.js
+++ b/src/apicache.js
@@ -1238,8 +1238,7 @@ function ApiCache() {
       if (
         opt.isBypassable &&
         (req.headers['cache-control'] === 'no-store' ||
-          ['1', 'true'].indexOf(req.headers['x-apicache-bypass']) !== -1 ||
-          ['1', 'true'].indexOf(req.headers['x-apicache-force-fetch']) !== -1)
+          ['1', 'true'].indexOf(req.headers['x-apicache-bypass']) !== -1)
       ) {
         return bypass()
       }
@@ -1356,6 +1355,10 @@ function ApiCache() {
           })
       }
 
+      if (['1', 'true'].indexOf(req.headers['x-apicache-force-fetch']) !== -1) {
+        debug('force fetch detected, refreshing cache.')
+        return maybeMakeResponseCacheable()
+      }
       return attemptCacheHit()
     }
 

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -1484,7 +1484,7 @@ describe('.middleware {MIDDLEWARE}', function() {
           })
       })
 
-      it('skips cache when using header "x-apicache-force-fetch (legacy)"', function() {
+      it('skips updates cache when using header "x-apicache-force-fetch"', function() {
         var app = mockAPI.create('10 seconds', { isBypassable: true })
 
         return request(app)
@@ -1539,28 +1539,6 @@ describe('.middleware {MIDDLEWARE}', function() {
             return request(app)
               .get('/api/movies')
               .set('x-apicache-bypass', true)
-              .set('Accept', 'application/json')
-              .expect('Content-Type', /json/)
-              .expect('apicache-store', 'memory')
-              .expect('apicache-version', pkg.version)
-              .expect(200, movies)
-              .then(function(res) {
-                expect(app.requestsProcessed).to.equal(1)
-              })
-          })
-      })
-
-      it('prevent cache skipping when using header "x-apicache-force-fetch (legacy)" with isBypassable "false"', function() {
-        var app = mockAPI.create('10 seconds', { isBypassable: false })
-
-        return request(app)
-          .get('/api/movies')
-          .expect(200, movies)
-          .then(assertNumRequestsProcessed(app, 1))
-          .then(function() {
-            return request(app)
-              .get('/api/movies')
-              .set('x-apicache-force-fetch', true)
               .set('Accept', 'application/json')
               .expect('Content-Type', /json/)
               .expect('apicache-store', 'memory')

--- a/test/apicache_test.js
+++ b/test/apicache_test.js
@@ -1484,7 +1484,7 @@ describe('.middleware {MIDDLEWARE}', function() {
           })
       })
 
-      it('skips updates cache when using header "x-apicache-force-fetch"', function() {
+      it('updates cache when using header "x-apicache-force-fetch"', function() {
         var app = mockAPI.create('10 seconds', { isBypassable: true })
 
         return request(app)


### PR DESCRIPTION
Scenario:  cache is set for 24 hours for load purposes but. a user with higher privilege is able to refresh the cached data via the client (data is pulled from external site)

Leveraged the existing `x-api-cache-force-fetch` vs having it behave the same way as `x-apicache-bypass`; which just skips over using the cache but doesn't update it for other updates.